### PR TITLE
Revert "chore(deps): update actions/setup-go action to v6"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v5
     
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     


### PR DESCRIPTION
This reverts commit 39910d8570b69406b542c275ce59aef12bf11cfe.