### PR TITLE
fix(getFLBPluginContext): use proper FLBPluginGetContext API and improve data parsing

### DIFF
--- a/out_writeapi.go
+++ b/out_writeapi.go
@@ -514,7 +514,7 @@ var getWriter = func(client ManagedWriterClient, ctx context.Context, projectID 
 // Mock it whenever needed
 var getFLBPluginContext = func(ctx unsafe.Pointer) int {
 	if ctx != nil {
-		return *(*int)(ctx)
+		return output.FLBPluginGetContext(ctx).(int)
 	}
 	return 0
 }

--- a/out_writeapi.go
+++ b/out_writeapi.go
@@ -197,11 +197,34 @@ func parseMap(mapInterface map[interface{}]interface{}) map[string]interface{} {
 			m[k.(string)] = string(t)
 		case map[interface{}]interface{}:
 			m[k.(string)] = parseMap(t)
+		case []interface{}:
+			m[k.(string)] = parseSlice(t)
 		default:
 			m[k.(string)] = v
 		}
 	}
 	return m
+}
+
+// Function to handle slices that may contain nested maps
+func parseSlice(sliceInterface []interface{}) []interface{} {
+	if sliceInterface == nil {
+		return nil
+	}
+	result := make([]interface{}, len(sliceInterface))
+	for i, v := range sliceInterface {
+		switch t := v.(type) {
+		case []byte:
+			result[i] = string(t)
+		case map[interface{}]interface{}:
+			result[i] = parseMap(t)
+		case []interface{}:
+			result[i] = parseSlice(t)
+		default:
+			result[i] = v
+		}
+	}
+	return result
 }
 
 var isReady = func(result *managedwriter.AppendResult) bool {

--- a/out_writeapi.go
+++ b/out_writeapi.go
@@ -81,6 +81,7 @@ const (
 	maxNumStreamsPerInstance   = 10
 	minQueueRequests           = 10
 	dateTimeDefault            = true
+	maxUnixSeconds             = 4102444800 // 2100-01-01 00:00:00 UTC in seconds
 )
 
 // This function mangles the top-level and complex (struct) BigQuery schema to convert NUMERIC, BIGNUMERIC, DATETIME, TIME, and JSON fields to STRING.
@@ -225,6 +226,34 @@ func parseSlice(sliceInterface []interface{}) []interface{} {
 		}
 	}
 	return result
+}
+
+// Convert timestamp fields from seconds to microseconds for BigQuery Storage Write API
+// BigQuery TIMESTAMP type expects microseconds since Unix epoch
+func convertTimestampFields(data map[string]interface{}, timestampFields []string) {
+	for _, field := range timestampFields {
+		if val, ok := data[field]; ok {
+			switch v := val.(type) {
+			case int64:
+				// If value looks like seconds (less than year 2100 in seconds), convert to microseconds
+				if v > 0 && v < maxUnixSeconds {
+					data[field] = v * 1000000
+				}
+			case int:
+				if v > 0 && v < maxUnixSeconds {
+					data[field] = int64(v) * 1000000
+				}
+			case uint64:
+				if v > 0 && v < maxUnixSeconds {
+					data[field] = int64(v) * 1000000
+				}
+			case float64:
+				if v > 0 && v < maxUnixSeconds {
+					data[field] = int64(v * 1000000)
+				}
+			}
+		}
+	}
 }
 
 var isReady = func(result *managedwriter.AppendResult) bool {
@@ -743,6 +772,9 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 		}
 
 		rowJSONMap := parseMap(record)
+
+		// Convert timestamp fields from seconds to microseconds for BigQuery Storage Write API
+		convertTimestampFields(rowJSONMap, []string{"time"})
 
 		// Serialize data
 		// Transform each row of data into binary using the jsonToBinary function and the message descriptor from the getDescriptors function

--- a/out_writeapi.go
+++ b/out_writeapi.go
@@ -63,6 +63,7 @@ type outputConfig struct {
 	exactlyOnce           bool
 	requestCountThreshold int
 	numRetries            int
+	timestampFields       []string
 }
 
 var (
@@ -118,9 +119,32 @@ func mangleInputSchema(input *storagepb.TableSchema, dataTimeString bool) *stora
 	return newMsg
 }
 
+// This function extracts TIMESTAMP field names from the BigQuery table schema
+func extractTimestampFields(schema *storagepb.TableSchema, prefix string) []string {
+	var fields []string
+	if schema == nil {
+		return fields
+	}
+	for _, f := range schema.GetFields() {
+		fieldName := f.GetName()
+		if prefix != "" {
+			fieldName = prefix + "." + fieldName
+		}
+		if f.GetType() == storagepb.TableFieldSchema_TIMESTAMP {
+			fields = append(fields, fieldName)
+		}
+		// Recursively extract from nested RECORD fields
+		if len(f.GetFields()) > 0 {
+			nestedFields := extractTimestampFields(&storagepb.TableSchema{Fields: f.GetFields()}, fieldName)
+			fields = append(fields, nestedFields...)
+		}
+	}
+	return fields
+}
+
 // This function handles getting data on the schema of the table data is being written to.
 // The getDescriptors function returns the message descriptor (which describes the schema of the corresponding table) as well as a descriptor proto
-func getDescriptors(curr_ctx context.Context, mw_client ManagedWriterClient, project string, dataset string, table string, dataTimeString bool) (protoreflect.MessageDescriptor, *descriptorpb.DescriptorProto, error) {
+func getDescriptors(curr_ctx context.Context, mw_client ManagedWriterClient, project string, dataset string, table string, dataTimeString bool) (protoreflect.MessageDescriptor, *descriptorpb.DescriptorProto, []string, error) {
 	// Create streamID specific to the project, dataset, and table
 	curr_stream := fmt.Sprintf("projects/%s/datasets/%s/tables/%s/streams/_default", project, dataset, table)
 
@@ -133,29 +157,33 @@ func getDescriptors(curr_ctx context.Context, mw_client ManagedWriterClient, pro
 	// Call getwritestream to get data on the table
 	table_data, err := mw_client.GetWriteStream(curr_ctx, &req)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	// Get the schema from table data
 	init_table_schema := table_data.GetTableSchema()
+
+	// Extract TIMESTAMP field names before mangling the schema
+	timestampFields := extractTimestampFields(init_table_schema, "")
+
 	table_schema := mangleInputSchema(init_table_schema, dataTimeString)
 	// Storage schema -> proto descriptor
 	descriptor, err := adapt.StorageSchemaToProto2Descriptor(table_schema, "root")
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	// Proto descriptor -> message descriptor
 	messageDescriptor, ok := descriptor.(protoreflect.MessageDescriptor)
 	if !ok {
-		return nil, nil, errors.New("Message descriptor could not be created from table's proto descriptor")
+		return nil, nil, nil, errors.New("Message descriptor could not be created from table's proto descriptor")
 	}
 
 	// Message descriptor -> descriptor proto
 	dp, err := adapt.NormalizeDescriptor(messageDescriptor)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return messageDescriptor, dp, nil
+	return messageDescriptor, dp, timestampFields, nil
 }
 
 // This function handles the data transformation from JSON to binary for a single json row.
@@ -251,6 +279,17 @@ func convertTimestampFields(data map[string]interface{}, timestampFields []strin
 				if v > 0 && v < maxUnixSeconds {
 					data[field] = int64(v * 1000000)
 				}
+			case string:
+				// Handle string timestamp (e.g., "1769419316")
+				if v != "" {
+					if floatVal, err := strconv.ParseFloat(v, 64); err == nil {
+						if floatVal > 0 && floatVal < maxUnixSeconds {
+							data[field] = int64(floatVal * 1000000)
+						} else {
+							data[field] = int64(floatVal)
+						}
+					}
+				}
 			}
 		}
 	}
@@ -266,7 +305,19 @@ var isReady = func(result *managedwriter.AppendResult) bool {
 }
 
 var pluginGetResult = func(result *managedwriter.AppendResult, ctx context.Context) (int64, error) {
-	return result.GetResult(ctx)
+	offset, err := result.GetResult(ctx)
+	if err != nil {
+		// Try to get detailed row errors from FullResponse
+		if fullResp, respErr := result.FullResponse(ctx); respErr == nil && fullResp != nil {
+			if rowErrors := fullResp.GetRowErrors(); len(rowErrors) > 0 {
+				for _, rowErr := range rowErrors {
+					log.Printf("Row error at index %d: code=%v, message=%s",
+						rowErr.GetIndex(), rowErr.GetCode(), rowErr.GetMessage())
+				}
+			}
+		}
+	}
+	return offset, err
 }
 
 // This function is used for asynchronous WriteAPI response checking
@@ -666,11 +717,12 @@ func FLBPluginInit(plugin unsafe.Pointer) int {
 	tableReference := fmt.Sprintf("projects/%s/datasets/%s/tables/%s", projectID, datasetID, tableID)
 
 	// Call getDescriptors to get the message descriptor, and descriptor proto
-	md, descriptor, err := getDescriptors(ms_ctx, client, projectID, datasetID, tableID, dateTimeStringType)
+	md, descriptor, timestampFields, err := getDescriptors(ms_ctx, client, projectID, datasetID, tableID, dateTimeStringType)
 	if err != nil {
 		log.Printf("Getting message descriptor and descriptor proto for table: %s failed in FLBPluginInit: %s", tableReference, err)
 		return output.FLB_ERROR
 	}
+	log.Printf("Detected TIMESTAMP fields from schema: %v", timestampFields)
 
 	// Set the stream type based on exactly once parameter
 	var currStreamType managedwriter.StreamType
@@ -708,6 +760,7 @@ func FLBPluginInit(plugin unsafe.Pointer) int {
 		numRetries:            numRetriesVal,
 		requestCountThreshold: requestCountThreshold,
 		managedStreamSlice:    &streamSlice,
+		timestampFields:       timestampFields,
 	}
 
 	// Create stream using NewManagedStream
@@ -774,7 +827,7 @@ func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int 
 		rowJSONMap := parseMap(record)
 
 		// Convert timestamp fields from seconds to microseconds for BigQuery Storage Write API
-		convertTimestampFields(rowJSONMap, []string{"time"})
+		convertTimestampFields(rowJSONMap, config.timestampFields)
 
 		// Serialize data
 		// Transform each row of data into binary using the jsonToBinary function and the message descriptor from the getDescriptors function

--- a/out_writeapi.go
+++ b/out_writeapi.go
@@ -186,6 +186,9 @@ func jsonToBinary(message_descriptor protoreflect.MessageDescriptor, jsonRow map
 // From https://github.com/majst01/fluent-bit-go-redis-output.git
 // Function is used to transform fluent-bit record to a JSON map
 func parseMap(mapInterface map[interface{}]interface{}) map[string]interface{} {
+	if mapInterface == nil {
+		return nil
+	}
 	m := make(map[string]interface{})
 	for k, v := range mapInterface {
 		switch t := v.(type) {

--- a/out_writeapi_test.go
+++ b/out_writeapi_test.go
@@ -1288,3 +1288,111 @@ func TestParseSlice(t *testing.T) {
 		})
 	}
 }
+
+// TestConvertTimestampFields tests the convertTimestampFields function
+func TestConvertTimestampFields(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           map[string]interface{}
+		timestampFields []string
+		expected        map[string]interface{}
+	}{
+		{
+			name:            "int64 seconds converted to microseconds",
+			input:           map[string]interface{}{"time": int64(1700000000)},
+			timestampFields: []string{"time"},
+			expected:        map[string]interface{}{"time": int64(1700000000000000)},
+		},
+		{
+			name:            "int seconds converted to microseconds",
+			input:           map[string]interface{}{"time": 1700000000},
+			timestampFields: []string{"time"},
+			expected:        map[string]interface{}{"time": int64(1700000000000000)},
+		},
+		{
+			name:            "uint64 seconds converted to microseconds",
+			input:           map[string]interface{}{"time": uint64(1700000000)},
+			timestampFields: []string{"time"},
+			expected:        map[string]interface{}{"time": int64(1700000000000000)},
+		},
+		{
+			name:            "float64 seconds converted to microseconds",
+			input:           map[string]interface{}{"time": float64(1700000000.5)},
+			timestampFields: []string{"time"},
+			expected:        map[string]interface{}{"time": int64(1700000000500000)},
+		},
+		{
+			name:            "value already in microseconds not converted",
+			input:           map[string]interface{}{"time": int64(1700000000000000)},
+			timestampFields: []string{"time"},
+			expected:        map[string]interface{}{"time": int64(1700000000000000)},
+		},
+		{
+			name:            "boundary value at maxUnixSeconds not converted",
+			input:           map[string]interface{}{"time": int64(4102444800)},
+			timestampFields: []string{"time"},
+			expected:        map[string]interface{}{"time": int64(4102444800)},
+		},
+		{
+			name:            "boundary value just below maxUnixSeconds converted",
+			input:           map[string]interface{}{"time": int64(4102444799)},
+			timestampFields: []string{"time"},
+			expected:        map[string]interface{}{"time": int64(4102444799000000)},
+		},
+		{
+			name:            "zero value not converted",
+			input:           map[string]interface{}{"time": int64(0)},
+			timestampFields: []string{"time"},
+			expected:        map[string]interface{}{"time": int64(0)},
+		},
+		{
+			name:            "negative value not converted",
+			input:           map[string]interface{}{"time": int64(-1000)},
+			timestampFields: []string{"time"},
+			expected:        map[string]interface{}{"time": int64(-1000)},
+		},
+		{
+			name:            "field not in timestampFields not converted",
+			input:           map[string]interface{}{"time": int64(1700000000), "other": int64(1700000000)},
+			timestampFields: []string{"time"},
+			expected:        map[string]interface{}{"time": int64(1700000000000000), "other": int64(1700000000)},
+		},
+		{
+			name:            "multiple timestamp fields",
+			input:           map[string]interface{}{"time": int64(1700000000), "created_at": int64(1600000000)},
+			timestampFields: []string{"time", "created_at"},
+			expected:        map[string]interface{}{"time": int64(1700000000000000), "created_at": int64(1600000000000000)},
+		},
+		{
+			name:            "field not present in data",
+			input:           map[string]interface{}{"other": "value"},
+			timestampFields: []string{"time"},
+			expected:        map[string]interface{}{"other": "value"},
+		},
+		{
+			name:            "string value not converted",
+			input:           map[string]interface{}{"time": "2023-11-14T00:00:00Z"},
+			timestampFields: []string{"time"},
+			expected:        map[string]interface{}{"time": "2023-11-14T00:00:00Z"},
+		},
+		{
+			name:            "empty timestamp fields",
+			input:           map[string]interface{}{"time": int64(1700000000)},
+			timestampFields: []string{},
+			expected:        map[string]interface{}{"time": int64(1700000000)},
+		},
+		{
+			name:            "nil timestamp fields",
+			input:           map[string]interface{}{"time": int64(1700000000)},
+			timestampFields: nil,
+			expected:        map[string]interface{}{"time": int64(1700000000)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			convertTimestampFields(tt.input, tt.timestampFields)
+			assert.Equal(t, tt.expected, tt.input)
+		})
+	}
+}

--- a/out_writeapi_test.go
+++ b/out_writeapi_test.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/agiledragon/gomonkey/v2"
 	"cloud.google.com/go/bigquery/storage/apiv1/storagepb"
 	"cloud.google.com/go/bigquery/storage/managedwriter"
 	"cloud.google.com/go/bigquery/storage/managedwriter/adapt"
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/fluent/fluent-bit-go/output"
 	"github.com/googleapis/gax-go/v2"
 	"github.com/stretchr/testify/assert"
@@ -1044,4 +1044,184 @@ func TestFLBPluginFlushCtxErrorHandling(t *testing.T) {
 	assert.Equal(t, 2, checks.getResultsCount)
 	assert.Equal(t, 2, checks.createDecoder)
 	assert.Equal(t, expectGotRecord, checks.gotRecord)
+}
+
+// TestParseMap tests the parseMap function
+func TestParseMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[interface{}]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name:     "nil map returns nil",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty map",
+			input:    map[interface{}]interface{}{},
+			expected: map[string]interface{}{},
+		},
+		{
+			name: "simple string values",
+			input: map[interface{}]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			expected: map[string]interface{}{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "byte slice values converted to string",
+			input: map[interface{}]interface{}{
+				"text": []byte("hello"),
+			},
+			expected: map[string]interface{}{
+				"text": "hello",
+			},
+		},
+		{
+			name: "nested map",
+			input: map[interface{}]interface{}{
+				"outer": map[interface{}]interface{}{
+					"inner": "value",
+				},
+			},
+			expected: map[string]interface{}{
+				"outer": map[string]interface{}{
+					"inner": "value",
+				},
+			},
+		},
+		{
+			name: "slice values",
+			input: map[interface{}]interface{}{
+				"list": []interface{}{"a", "b", "c"},
+			},
+			expected: map[string]interface{}{
+				"list": []interface{}{"a", "b", "c"},
+			},
+		},
+		{
+			name: "slice with nested map",
+			input: map[interface{}]interface{}{
+				"items": []interface{}{
+					map[interface{}]interface{}{
+						"name": "item1",
+					},
+					map[interface{}]interface{}{
+						"name": "item2",
+					},
+				},
+			},
+			// Note: parseMap does not recursively process elements inside slices
+			expected: map[string]interface{}{
+				"items": []interface{}{
+					map[interface{}]interface{}{
+						"name": "item1",
+					},
+					map[interface{}]interface{}{
+						"name": "item2",
+					},
+				},
+			},
+		},
+		{
+			name: "slice with byte slice",
+			input: map[interface{}]interface{}{
+				"data": []interface{}{
+					[]byte("first"),
+					[]byte("second"),
+				},
+			},
+			// Note: parseMap does not recursively process elements inside slices
+			expected: map[string]interface{}{
+				"data": []interface{}{
+					[]byte("first"),
+					[]byte("second"),
+				},
+			},
+		},
+		{
+			name: "integer and float values",
+			input: map[interface{}]interface{}{
+				"int":   42,
+				"float": 3.14,
+			},
+			expected: map[string]interface{}{
+				"int":   42,
+				"float": 3.14,
+			},
+		},
+		{
+			name: "boolean values",
+			input: map[interface{}]interface{}{
+				"true":  true,
+				"false": false,
+			},
+			expected: map[string]interface{}{
+				"true":  true,
+				"false": false,
+			},
+		},
+		{
+			name: "deeply nested structure",
+			input: map[interface{}]interface{}{
+				"level1": map[interface{}]interface{}{
+					"level2": map[interface{}]interface{}{
+						"level3": []interface{}{
+							map[interface{}]interface{}{
+								"data": []byte("deep"),
+							},
+						},
+					},
+				},
+			},
+			// Note: parseMap does not recursively process elements inside slices
+			expected: map[string]interface{}{
+				"level1": map[string]interface{}{
+					"level2": map[string]interface{}{
+						"level3": []interface{}{
+							map[interface{}]interface{}{
+								"data": []byte("deep"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "mixed types",
+			input: map[interface{}]interface{}{
+				"string":  "text",
+				"bytes":   []byte("binary"),
+				"number":  123,
+				"boolean": true,
+				"nested": map[interface{}]interface{}{
+					"key": "value",
+				},
+				"list": []interface{}{1, 2, 3},
+			},
+			expected: map[string]interface{}{
+				"string":  "text",
+				"bytes":   "binary",
+				"number":  123,
+				"boolean": true,
+				"nested": map[string]interface{}{
+					"key": "value",
+				},
+				"list": []interface{}{1, 2, 3},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseMap(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/out_writeapi_test.go
+++ b/out_writeapi_test.go
@@ -1117,13 +1117,12 @@ func TestParseMap(t *testing.T) {
 					},
 				},
 			},
-			// Note: parseMap does not recursively process elements inside slices
 			expected: map[string]interface{}{
 				"items": []interface{}{
-					map[interface{}]interface{}{
+					map[string]interface{}{
 						"name": "item1",
 					},
-					map[interface{}]interface{}{
+					map[string]interface{}{
 						"name": "item2",
 					},
 				},
@@ -1137,11 +1136,10 @@ func TestParseMap(t *testing.T) {
 					[]byte("second"),
 				},
 			},
-			// Note: parseMap does not recursively process elements inside slices
 			expected: map[string]interface{}{
 				"data": []interface{}{
-					[]byte("first"),
-					[]byte("second"),
+					"first",
+					"second",
 				},
 			},
 		},
@@ -1180,13 +1178,12 @@ func TestParseMap(t *testing.T) {
 					},
 				},
 			},
-			// Note: parseMap does not recursively process elements inside slices
 			expected: map[string]interface{}{
 				"level1": map[string]interface{}{
 					"level2": map[string]interface{}{
 						"level3": []interface{}{
-							map[interface{}]interface{}{
-								"data": []byte("deep"),
+							map[string]interface{}{
+								"data": "deep",
 							},
 						},
 					},
@@ -1221,6 +1218,72 @@ func TestParseMap(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := parseMap(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestParseSlice tests the parseSlice function
+func TestParseSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []interface{}
+		expected []interface{}
+	}{
+		{
+			name:     "nil slice returns nil",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty slice",
+			input:    []interface{}{},
+			expected: []interface{}{},
+		},
+		{
+			name:     "simple values",
+			input:    []interface{}{"a", "b", "c"},
+			expected: []interface{}{"a", "b", "c"},
+		},
+		{
+			name:     "byte slice converted to string",
+			input:    []interface{}{[]byte("hello"), []byte("world")},
+			expected: []interface{}{"hello", "world"},
+		},
+		{
+			name: "nested map in slice",
+			input: []interface{}{
+				map[interface{}]interface{}{
+					"key": "value",
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"key": "value",
+				},
+			},
+		},
+		{
+			name: "nested slice",
+			input: []interface{}{
+				[]interface{}{1, 2, 3},
+				[]interface{}{"a", "b"},
+			},
+			expected: []interface{}{
+				[]interface{}{1, 2, 3},
+				[]interface{}{"a", "b"},
+			},
+		},
+		{
+			name:     "mixed types",
+			input:    []interface{}{"string", []byte("bytes"), 42, true},
+			expected: []interface{}{"string", "bytes", 42, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseSlice(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
## Summary
This PR fixes plugin context retrieval by switching to the official Fluent Bit Go API (`output.FLBPluginGetContext()`).
It also improves record parsing by safely handling `nil`, recursively processing nested structures, and normalizing timestamps for fluentd→fluent-bit migration compatibility.

## Background

1. The previous implementation used direct pointer casting to retrieve the plugin context, which could lead to incorrect behavior. The proper `output.FLBPluginGetContext()` API should be used instead.

2. The `parseMap` function did not handle `nil` input safely, potentially causing panics.

3. Elements inside slices (nested maps, byte slices) were not being recursively processed by `parseMap`, which could cause issues when serializing data for BigQuery.

4. When migrating from fluentd ([fluent-plugins-nursery/fluent-plugin-bigquery](https://github.com/fluent-plugins-nursery/fluent-plugin-bigquery)) to fluent-bit, timestamp fields may be emitted as Unix seconds instead of the microseconds expected by the BigQuery Storage Write API, resulting in incorrect timestamp values (e.g., dates appearing as 1970-01-01).


## Changes

- **getFLBPluginContext**: Replace direct pointer casting with `output.FLBPluginGetContext()` to correctly retrieve the plugin context
- **parseMap**: Add nil check to safely return nil for nil input
- **parseSlice**: Add new function to recursively process slice elements (byte slice conversion, nested maps/slices), with nil check
- **parseMap**: Update to call `parseSlice` for `[]interface{}` values, enabling full recursive processing
- **convertTimestampFields**: Add new function to convert timestamp fields from Unix seconds to microseconds for BigQuery compatibility (values less than year 2100 in seconds are converted)
- **maxUnixSeconds**: Add constant for timestamp conversion threshold (4102444800 = 2100-01-01 00:00:00 UTC)

## Test Plan

- Added unit tests for `parseMap` covering nil input, empty maps, nested structures, and various data types
- Added unit tests for `parseSlice` covering nil input, empty slices, byte slice conversion, nested maps, and mixed types
- Added unit tests for `convertTimestampFields` covering:
  - Different numeric types (int64, int, uint64, float64)
  - Boundary values (maxUnixSeconds threshold)
  - Already-microsecond values (no conversion)