### PR TITLE
fix: Finding configuration for output instance failed

### DIFF
--- a/out_writeapi.go
+++ b/out_writeapi.go
@@ -513,10 +513,7 @@ var getWriter = func(client ManagedWriterClient, ctx context.Context, projectID 
 // This function acts as a wrapper for the GetContext function so that we may override it to
 // Mock it whenever needed
 var getFLBPluginContext = func(ctx unsafe.Pointer) int {
-	if ctx != nil {
-		return *(*int)(ctx)
-	}
-	return 0
+	return output.FLBPluginGetContext(ctx).(int)
 }
 
 // Finalizes and Closes all streams in slice for a given instance

--- a/out_writeapi_test.go
+++ b/out_writeapi_test.go
@@ -425,10 +425,7 @@ func TestFLBPluginFlushCtx(t *testing.T) {
 	orgFunc := getFLBPluginContext
 	getFLBPluginContext = func(ctx unsafe.Pointer) int {
 		checks.calledGetContext++
-		if ctx != nil {
-			return *(*int)(ctx)
-		}
-		return 0
+		return setID
 	}
 	defer func() { getFLBPluginContext = orgFunc }()
 
@@ -793,10 +790,7 @@ func TestFLBPluginFlushCtxExactlyOnce(t *testing.T) {
 	orgFunc := getFLBPluginContext
 	getFLBPluginContext = func(ctx unsafe.Pointer) int {
 		checks.calledGetContext++
-		if ctx != nil {
-			return *(*int)(ctx)
-		}
-		return 0
+		return setID
 	}
 	defer func() { getFLBPluginContext = orgFunc }()
 
@@ -966,10 +960,7 @@ func TestFLBPluginFlushCtxErrorHandling(t *testing.T) {
 	orgFunc := getFLBPluginContext
 	getFLBPluginContext = func(ctx unsafe.Pointer) int {
 		checks.calledGetContext++
-		if ctx != nil {
-			return *(*int)(ctx)
-		}
-		return 0
+		return setID
 	}
 	defer func() { getFLBPluginContext = orgFunc }()
 


### PR DESCRIPTION
Since this commit 7dd5c1fb0e5aad939623cace84a168ba69ee3ee1, the output plugin has not been working properly, so I have reverted the relevant code.
The error is like as follows:

```
Finding configuration for output instance with id: xxxx failed in FLBPluginFlushCtx
```

go version go1.24.4 linux/arm64
Fluent Bit v4.2.3